### PR TITLE
Removing references to "Council" & Fixing format issues in the sidebar menu & footer for admin and help pages

### DIFF
--- a/perllib/FixMyStreet/App/Controller/Council.pm
+++ b/perllib/FixMyStreet/App/Controller/Council.pm
@@ -99,7 +99,7 @@ sub load_and_check_areas : Private {
     # If we don't have any areas we can't accept the report
     if ( !scalar keys %$all_areas ) {
         $c->stash->{location_error_no_areas} = 1;
-        $c->stash->{location_error} = _('That location does not appear to be covered by a council; perhaps it is offshore or outside the country. Please try again.');
+        $c->stash->{location_error} = _('The selected location is outside of Kythera island. Please try again.');
         return;
     }
 

--- a/t/app/controller/report_new_errors.t
+++ b/t/app/controller/report_new_errors.t
@@ -723,7 +723,7 @@ subtest "check that a lat/lon off coast leads to /around" => sub {
 
     is_deeply
       $mech->page_errors,
-      [ 'That location does not appear to be covered by a council; perhaps it is offshore or outside the country. Please try again.' ],
+      [ 'The selected location is outside of Kythera island. Please try again.' ],
       "Found location error";
 
 };

--- a/templates/email/fmsk/submit.html
+++ b/templates/email/fmsk/submit.html
@@ -1,0 +1,68 @@
+[%
+
+email_footer = "If there is a more appropriate email address for messages about " _ category_footer _ ", please let us know. This will help improve the service. We also welcome any other feedback you may have."
+email_columns = 2;
+
+PROCESS '_email_settings.html';
+
+INCLUDE '_email_top.html';
+
+%]
+
+<th style="[% td_style %][% primary_column_style %]" id="primary_column">
+  [% start_padded_box | safe %]
+  <h1 style="[% h1_style %]">New problem in your&nbsp;area</h1>
+  <p style="[% p_style %]">[% missing %][% multiple %]A user of [% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.</p>
+
+  <p style="margin: 20px auto; text-align: center">
+    <a style="[% button_style %]" href="[% url %]">Show full report</a>
+  </p>
+  <h2 style="[% h2_style %] margin: 30px 0 10px 0">Reported by:</h2>
+  <table [% table_reset | safe %]>
+    <tr>
+      <th style="[% contact_th_style %]">Name</th>
+      <td style="[% contact_td_style %]">[% report.name | html %]</td>
+    </tr>
+    <tr>
+      <th style="[% contact_th_style %]">Email</th>
+      <td style="[% contact_td_style %]">
+        [%~ IF report.user.email ~%]
+          <a href="mailto:[% report.user.email | html %]">[% report.user.email | html %]</a>
+        [%~ ELSE ~%]
+          <strong>No email address provided, only phone number</strong>
+        [%~ END ~%]
+      </td>
+    </tr>
+    [%~ IF report.user.phone %]
+      <tr>
+        <th style="[% contact_th_style %]">Phone</th>
+        <td style="[% contact_td_style %]"><a href="tel:[% report.user.phone | html %]">[% report.user.phone | html %]</a></td>
+      </tr>
+    [%~ END %]
+  </table>
+  <p style="[% p_style %] margin-top: 0.5em;">Replies to this message will go directly to [% report.name | html %], the user who reported the problem.</p>
+  [% end_padded_box | safe %]
+</th>
+[% WRAPPER '_email_sidebar.html' object = report %]
+    <h2 style="[% h2_style %]">[% report.title | html %]</h2>
+    <p style="[% secondary_p_style %]">[% report.category | html %]</p>
+    [% report.detail | html_para_email(secondary_p_style) %]
+  [% IF report.get_extra_fields %]
+    <p style="[% secondary_p_style %]">
+      [%~ FOR field IN report.get_extra_fields %][% IF field.value_label OR field.value.length %]
+      [% field.description OR field.name %]: [% field.value_label OR field.value %]
+      [% IF NOT loop.last %]<br>[% END %]
+      [%~ END %][% END %]
+    </p>
+  [% END %]
+    <p style="[% secondary_p_style %]">
+      <strong>Location:</strong>
+      <a href="[% osm_url %]" title="View OpenStreetMap of this location">
+        [%~ report.latitude %], [% report.longitude ~%]
+      </a>
+      [% IF closest_address %]<br>[% closest_address | trim | replace("\n\n", "<br>") %][% END %]
+    </p>
+[% END %]
+
+[% INCLUDE '_email_bottom.html' %]

--- a/templates/email/fmsk/submit.txt
+++ b/templates/email/fmsk/submit.txt
@@ -1,0 +1,47 @@
+Subject: Problem Report: [% report.title %]
+
+Dear [% bodies_name %],
+
+[% missing %][% multiple %]A user of
+[% site_name %] has submitted the following report
+of a local problem that they believe might require your attention.
+
+[% fuzzy %], or to provide an update on the problem,
+please visit the following link:
+
+    [% url %]
+
+[% has_photo %]----------
+
+Name: [% report.name %]
+
+Email: [% report.user.email OR "None provided" %]
+
+Phone: [% report.user.phone OR "None provided" %]
+
+Category: [% report.category %]
+
+Subject: [% report.title %]
+
+Details: [% report.detail %]
+
+[% FOR field IN report.get_extra_fields %][% IF field.value_label OR field.value.length ~%]
+[% field.description OR field.name %]: [% field.value_label OR field.value %]
+
+[% END %][% END ~%]
+
+Latitude: [% report.latitude %]
+
+Longitude: [% report.longitude %]
+
+View OpenStreetMap of this location: [% osm_url %]
+
+[% closest_address %]----------
+
+Replies to this email will go to the user who submitted the problem.
+
+[% signature %]
+
+If there is a more appropriate email address for messages about
+[% category_footer %], please let us know. This will help improve the
+service. We also welcome any other feedback you may have.

--- a/templates/web/fmsk/about/cookies.html
+++ b/templates/web/fmsk/about/cookies.html
@@ -48,4 +48,4 @@ user during the same visit. (anonymously – no personal information is collecte
 cookie, 30 minutes</p>
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/about/faq-el.html
+++ b/templates/web/fmsk/about/faq-el.html
@@ -131,4 +131,4 @@ href="https://www.mysociety.org/helpus/">Get Involved page</a>.</dd>
 
 </dl>
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/about/faq-en-gb.html
+++ b/templates/web/fmsk/about/faq-en-gb.html
@@ -77,4 +77,4 @@ Email: <a href='mailto:jon.switters@lisboncouncil.net' target='_blank' class='ur
 <p>&nbsp;</p>
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/about/privacy.html
+++ b/templates/web/fmsk/about/privacy.html
@@ -107,4 +107,4 @@ Email: <a href='mailto:jon.switters@lisboncouncil.net' target='_blank' class='ur
 <p>&nbsp;</p>
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/about/tos.html
+++ b/templates/web/fmsk/about/tos.html
@@ -27,4 +27,4 @@
 
 
 
-[% INCLUDE 'footer.html' pagefooter = 'yes' %]
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/admin/header.html
+++ b/templates/web/fmsk/admin/header.html
@@ -1,0 +1,20 @@
+[%
+    SET admin = 1;
+    SET bodyclass = bodyclass.defined && bodyclass != '' ? bodyclass : 'twothirdswidthpage';
+    INCLUDE 'header.html' bodyclass=bodyclass _ ' admin';
+%]
+
+[% IF !bodyclass.match('mappage') %]
+[%   INCLUDE 'admin/navigation.html' %]
+[% END %]
+
+<style type="text/css">
+dt { clear: left; float: left; font-weight: bold; }
+dd { margin-left: 8em !important; }
+.adminhidden { color: #666666; }
+.error { color: red; }
+select { width: auto; max-width: 100%; }
+.sm { font-size: smaller; }
+</style>
+
+[% IF !bodyclass.match('mappage') %]<h1>[% title %]</h1>[% END %]

--- a/templates/web/fmsk/around/postcode_form.html
+++ b/templates/web/fmsk/around/postcode_form.html
@@ -5,7 +5,7 @@
         [% END %]
 
         [%
-            question = c.cobrand.enter_postcode_text || loc('Enter the approximate location along one of Kythera Trails');
+            question = c.cobrand.enter_postcode_text || loc('Click below to use your GPS position (preferred), or search for a location or landmark along one of the Kythera Trails');
         %]
 
         <div class="hidden js-continue-draft draft-info-box">

--- a/templates/web/fmsk/contact/blurb.html
+++ b/templates/web/fmsk/contact/blurb.html
@@ -1,0 +1,9 @@
+<p>
+[% tprintf( loc("It's often quickest to <a href=\"%s\">check our FAQs</a> and see if the answer is there."), c.uri_for('/faq') ) %]
+</p>
+
+<p>
+[% loc('Please do <strong>not</strong> report problems through this form; messages go to
+the team behind this site, not to KIPA (responsible for Kythera Trails). To submit a report about the trails,
+please <a href="/">go to the front page</a> and follow the instructions.') %]
+</p>

--- a/templates/web/fmsk/contact/index.html
+++ b/templates/web/fmsk/contact/index.html
@@ -1,0 +1,28 @@
+[% extra_js = [
+    version('/js/contact.js')
+] -%]
+[% INCLUDE 'header.html',
+    title = loc('Contact Us')
+    robots = 'noindex,nofollow'
+    bodyclass = 'twothirdswidthpage'
+%]
+
+[% INCLUDE 'about/_sidebar.html' %]
+
+<h1>[% loc('Contact the team') %]</h1>
+
+[% INCLUDE 'contact/form.html' %]
+
+[% TRY %]
+    [% INCLUDE 'contact/_footer.html' %]
+[% CATCH file %]
+    <h4>[% loc("Don't like forms?") %]</h4>
+
+    <p>
+    [% tprintf( loc("You can contact technical support on <a href='mailto:%s'>%s</a>"), contact_email, contact_email) %]
+    </p>
+[% END %]
+
+[% TRY %][% INCLUDE 'contact/address.html' %][% CATCH file %][% END %]
+
+[% INCLUDE 'footer_help.html' pagefooter = 'yes' %]

--- a/templates/web/fmsk/footer_help.html
+++ b/templates/web/fmsk/footer_help.html
@@ -1,0 +1,16 @@
+[% RETURN IF ajax_loading ~%]
+                </div><!-- .content role=main -->
+                    [% IF pagefooter %]
+                    <footer role="contentinfo">
+                        [% INCLUDE 'front/footer-marketing.html' %]
+                    </footer>
+                    [% END %]
+
+            </div><!-- .container -->
+        </div><!-- .table-cell -->
+    </div> <!-- .wrapper -->
+
+    [% INCLUDE 'common_footer_tags.html' %]
+
+</body>
+</html>

--- a/templates/web/fmsk/main_nav_items.html
+++ b/templates/web/fmsk/main_nav_items.html
@@ -12,15 +12,6 @@
 
 [%~ INCLUDE 'navigation/_all_reports.html' ~%]
 
-[%~
-  IF pc;
-    pc_uri = pc | uri;
-    pc_suffix = "/list?pc=" _ pc_uri;
-  END;
-
-  INCLUDE navitem uri='/alert' label=loc('Local alerts') suffix=pc_suffix;
-~%]
-
 [%~ INCLUDE navitem uri='/faq' label=loc('Help') ~%]
 
 [%~ UNLESS hide_privacy_link ~%]

--- a/templates/web/fmsk/reports/index.html
+++ b/templates/web/fmsk/reports/index.html
@@ -1,0 +1,79 @@
+[% USE Number.Format -%]
+[% extra_js = [
+    version('/vendor/chart.min.js'),
+    version('/vendor/accessible-autocomplete.min.js'),
+    version('/js/dashboard.js')
+] -%]
+[%
+    problems_reported = problems_reported_by_period.last | format_number;
+    problems_fixed = problems_fixed_by_period.last | format_number;
+    last_seven_reported = last_seven_days.problems_total | format_number;
+    last_seven_updated = last_seven_days.updated_total | format_number;
+    last_seven_fixed = last_seven_days.fixed_total | format_number;
+    other_categories_formatted = other_categories | format_number;
+-%]
+[% INCLUDE 'header.html', title = loc('Dashboard'), bodyclass = 'dashboard' %]
+
+<div class="dashboard-header">
+    <h1>[% loc('Dashboard') %]
+    [% IF body %] – [% body.name %] [% END %]
+    </h1>
+</div>
+
+<div class="dashboard-row">
+    <div class="dashboard-item dashboard-item--12">
+        <h2>[% loc('All time') %]</h2>
+        <div class="labelled-line-chart">
+            <canvas id="chart-all-reports" width="600" height="250"
+                data-labels="[[% FOR period IN problem_periods %]&quot;[% period %]&quot;[% IF NOT loop.last %],[% END %][% END %]]"
+                data-values-reports="[[% problems_reported_by_period.join(',') %]]"
+                data-values-fixed="[[% problems_fixed_by_period.join(',') %]]"
+                ></canvas>
+            <span class="label" data-datasetindex="0"><strong style="color: #D97B0C">[% tprintf(nget("%s problem reported", "%s problems reported", problems_reported_by_period.last), decode(problems_reported) _ '</strong>') %]</span>
+            <span class="label" data-datasetindex="1"><strong style="color: #56A54A">[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", problems_fixed_by_period.last), decode(problems_fixed) _ '</strong>') %]</span>
+        </div>
+    </div>
+</div>
+
+<div class="dashboard-row">
+    <div class="dashboard-item dashboard-item--6">
+        <h2 class="dashboard-subheading">[% loc('Last 7 days') %]</h2>
+        <div class="dashboard-sparklines">
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#D97B0C" data-values="[% last_seven_days.problems.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #D97B0C;">[% tprintf(nget("%s problem reported", "%s problems reported", last_seven_days.problems_total), decode(last_seven_reported) _ '</strong>') %]</span>
+                </div>
+            </div>
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#269AE9" data-values="[% last_seven_days.updated.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #269AE9;">[% tprintf(nget("%s update on problems", "%s updates on problems", last_seven_days.updated_total), decode(last_seven_updated) _ '</strong>') %]</span>
+                </div>
+            </div>
+            <div>
+                <div class="labelled-sparkline">
+                    <canvas width="200" height="50" data-color="#56A54A" data-values="[% last_seven_days.fixed.join(' ') %]"></canvas>
+                    <span class="label" data-datasetindex="0"><strong style="color: #56A54A;">[% tprintf(nget("%s problem marked as fixed", "%s problems marked as fixed", last_seven_days.fixed_total), decode(last_seven_fixed) _ '</strong>') %]</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="dashboard-item dashboard-item--6">
+        <h2 class="dashboard-subheading">[% loc('Top 5 most used categories') %]</h2>
+        <p>[% loc('Number of problems reported in each category, in the last 7 days.') %]</p>
+        <table class="dashboard-ranking-table">
+            <tbody>
+              [% FOR line IN top_five_categories %]
+                [% line_count = line.count | format_number ~%]
+                <tr><td>[% line.category %]</td><td>[% tprintf(nget("%s report", "%s reports", line.count), decode(line_count)) %]</td></tr>
+              [% END %]
+            </tbody>
+            <tfoot>
+                <tr><td>[% loc('Other categories') %]</td><td>[% tprintf(nget("%s report", "%s reports", other_categories), decode(other_categories_formatted)) %]</td></tr>
+            </tfoot>
+        </table>
+    </div>
+</div>
+
+[% INCLUDE 'footer.html' pagefooter = 'yes' %]


### PR DESCRIPTION
Updates:

- Hide "Show reports in your area" box from "All reports" as it is just one area & Hide / remove "Top 5 responsive councils" from "All reports" as it is just one council/body. Test by navigating to [All reports](https://fmsk.lisboncouncilresearch.com/reports) (pending to change to "Statistics").
- Contact form menu displayed correctly. Test by navigating to [Contact](https://fmsk.lisboncouncilresearch.com/contact).
- Footer displayed properly at Help pages. Test by navigating to any help page, such as [FAQs](https://fmsk.lisboncouncilresearch.com/faq).
- Admin menu displayed correctly. Test by logging in as superadmin and navigating to [Admin](https://manrupi.jonava.lt/admin).
- Remove "Local Alerts" from the menuUpdated some literals in English: [FMSK - edits to text and translations 2025](https://docs.google.com/spreadsheets/d/1t4Oz2RFEAVm8bLdhu4DDsaG3Xehil1UrgUVdPi1JC-c/edit?usp=sharing)